### PR TITLE
Added dark variant to pop-up, style adjustment, fixed bug with timestamp

### DIFF
--- a/src/app/components/error-report/error-report.component.css
+++ b/src/app/components/error-report/error-report.component.css
@@ -141,11 +141,6 @@
   justify-content: flex-end;
 }
 
-.zlux-button.dark {
-  background-color: #3975d0;
-  color: #f3f4f4;
-}
-
 .timestamp {
   font-size: 12px;
   padding-left: 12px;

--- a/src/app/components/error-report/error-report.component.css
+++ b/src/app/components/error-report/error-report.component.css
@@ -25,6 +25,11 @@
   background-color: rgba(242, 242, 242, 1);
 }
 
+.report.warning.dark {
+  background-color: #24272d;
+  color: #dddee0;
+}
+
 .report.info {
   background-color: rgba(242, 242, 242, 1);
 }
@@ -68,6 +73,10 @@
   background-repeat: no-repeat;
 }
 
+.severityIcon.dark {
+  filter: invert(50%) sepia(50%) saturate(4000%) hue-rotate(0deg); /* ~Zowe support 02 (#e99023) */
+}
+
 .error .leftPanel {
   background-color: rgba(255, 92, 73, 1);
 }
@@ -78,6 +87,10 @@
 
 .warning .leftPanel {
   background-color: rgba(254, 133, 0, 1);
+}
+
+.warning .leftPanel.dark {
+  background-color: #dddee0; /* Zowe cool grey 20 */
 }
 
 .info .leftPanel {
@@ -112,8 +125,8 @@
 }
 
 .warning .title {
-  border-bottom-color: #DB7C00;
-  color: #DB7C00;
+  border-bottom-color: #e99023;
+  color: #e99023;
 }
 
 .info .title {
@@ -126,6 +139,11 @@
   display: flex;
   flex-direction: row;
   justify-content: flex-end;
+}
+
+.zlux-button.dark {
+  background-color: #3975d0;
+  color: #f3f4f4;
 }
 
 .timestamp {

--- a/src/app/components/error-report/error-report.component.html
+++ b/src/app/components/error-report/error-report.component.html
@@ -34,11 +34,10 @@
       ngClass="buttonArea"
     >
       <zlux-button
-        [ngClass]="theme"
         *ngFor="let button of buttons"
         [label]="button"
         (click)="action.emit(button)"
-        [callToAction]="false"
+        [callToAction]="callToAction || false"
       >
       </zlux-button>
     </div>

--- a/src/app/components/error-report/error-report.component.html
+++ b/src/app/components/error-report/error-report.component.html
@@ -10,9 +10,9 @@
   Copyright Contributors to the Zowe Project.
 -->
 
-<div [ngClass]="'report ' + severity">
-  <div ngClass="leftPanel">
-    <div ngClass="severityIcon">
+<div [ngClass]="'report ' + severity + ' ' + theme" [ngStyle]="style">
+  <div [ngClass]="'leftPanel ' + theme">
+    <div [ngClass]="'severityIcon ' + theme">
     </div>
   </div>
   <div ngClass="mainPanel">
@@ -34,6 +34,7 @@
       ngClass="buttonArea"
     >
       <zlux-button
+        [ngClass]="theme"
         *ngFor="let button of buttons"
         [label]="button"
         (click)="action.emit(button)"

--- a/src/app/components/error-report/error-report.component.ts
+++ b/src/app/components/error-report/error-report.component.ts
@@ -23,6 +23,8 @@ import { ZluxButtonModule } from '../button/button.component';
 export class ZluxErrorReportComponent {
 	@Input() severity: string = 'error';
   @Input() title: string = '';
+  @Input() theme: string;
+  @Input() style: any = {};
   @Input() buttons: string[] = [];
   @Input() timestamp: Date | undefined = undefined;
 

--- a/src/app/components/error-report/error-report.component.ts
+++ b/src/app/components/error-report/error-report.component.ts
@@ -27,6 +27,7 @@ export class ZluxErrorReportComponent {
   @Input() style: any = {};
   @Input() buttons: string[] = [];
   @Input() timestamp: Date | undefined = undefined;
+  @Input() callToAction: boolean;
 
   @Output() action: EventEmitter<any> = new EventEmitter<any>();
 

--- a/src/app/components/popup-manager/popup-manager.component.html
+++ b/src/app/components/popup-manager/popup-manager.component.html
@@ -26,6 +26,7 @@
       (action)="onChoose(currentErrorBlocking, $event)"
       [theme]="currentErrorBlocking.theme"
       [style]="currentErrorBlocking.style"
+      [callToAction]="currentErrorBlocking.callToAction"
     >
       {{currentErrorBlocking.text}}
     </zlux-error-report>
@@ -47,6 +48,7 @@
     (action)="onChoose(currentErrorNonblocking, $event)"
     [theme]="currentErrorNonblocking.theme"
     [style]="currentErrorNonblocking.style"
+    [callToAction]="currentErrorNonblocking.callToAction"
   >
     {{currentErrorNonblocking.text}}
   </zlux-error-report>

--- a/src/app/components/popup-manager/popup-manager.component.html
+++ b/src/app/components/popup-manager/popup-manager.component.html
@@ -24,6 +24,8 @@
       [timestamp]="currentErrorBlocking.timestamp"
       [buttons]="currentErrorBlocking.buttonCaptions"
       (action)="onChoose(currentErrorBlocking, $event)"
+      [theme]="currentErrorBlocking.theme"
+      [style]="currentErrorBlocking.style"
     >
       {{currentErrorBlocking.text}}
     </zlux-error-report>
@@ -43,6 +45,8 @@
     [timestamp]="currentErrorNonblocking.timestamp"
     [buttons]="currentErrorNonblocking.buttonCaptions"
     (action)="onChoose(currentErrorNonblocking, $event)"
+    [theme]="currentErrorNonblocking.theme"
+    [style]="currentErrorNonblocking.style"
   >
     {{currentErrorNonblocking.text}}
   </zlux-error-report>

--- a/src/app/services/popup-manager.service.ts
+++ b/src/app/services/popup-manager.service.ts
@@ -27,7 +27,8 @@ export interface ErrorReportStruct {
   timestamp: Date,
   subject: Rx.Subject<any>,
   theme?: string,
-  style?: {}
+  style?: {},
+  callToAction?: boolean
 }
 
 export enum ZluxErrorSeverity {
@@ -124,10 +125,6 @@ export class ZluxPopupManagerService {
 
     buttons = this.processButtons(buttons);
     const subject = new Rx.ReplaySubject();
-
-    const theme: string = options.theme || "";
-
-    const style: any = options.style || {};
     
     let errorReport: ErrorReportStruct = {
       severity,
@@ -138,8 +135,9 @@ export class ZluxPopupManagerService {
       timestamp,
       id: getSimpleID(),
       modal: options.blocking || false,
-      theme,
-      style
+      theme: options.theme || "",
+      style: options.style || {},
+      callToAction: options.callToAction || false
     };
 
     //the object will be shallow cloned

--- a/src/app/services/popup-manager.service.ts
+++ b/src/app/services/popup-manager.service.ts
@@ -25,7 +25,9 @@ export interface ErrorReportStruct {
   buttons: string[],
   id: number,
   timestamp: Date,
-  subject: Rx.Subject<any>
+  subject: Rx.Subject<any>,
+  theme?: string,
+  style?: {}
 }
 
 export enum ZluxErrorSeverity {
@@ -113,10 +115,19 @@ export class ZluxPopupManagerService {
   createErrorReport(severity: ZluxErrorSeverity, title: string, text: string, options?: any): ErrorReportStruct {
     options = options || {};
     let buttons = options.buttons || ["Close"];
-    const timestamp: Date = options.timestamp || new Date();
+    let timestamp: Date;
+    if (options.timestamp == false) {
+      timestamp = undefined;
+    } else {
+      timestamp = options.timestamp || new Date();
+    }
 
     buttons = this.processButtons(buttons);
     const subject = new Rx.ReplaySubject();
+
+    const theme: string = options.theme || "";
+
+    const style: any = options.style || {};
     
     let errorReport: ErrorReportStruct = {
       severity,
@@ -126,7 +137,9 @@ export class ZluxPopupManagerService {
       subject,
       timestamp,
       id: getSimpleID(),
-      modal: options.blocking || false
+      modal: options.blocking || false,
+      theme,
+      style
     };
 
     //the object will be shallow cloned


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/20528015/81602754-2cdb3980-939b-11ea-9142-26c946b1544a.png)

- Added ability for users to adjust outer style
- Added support for themes (added "dark" for desktop redesign)
- Fixed a bug where explicitly not wanting to show timestamp would still show it 
Signed-off-by: Leanid Astrakou <lastrakou@rocketsoftware.com>